### PR TITLE
[STEP 1 & 2 ] Summer, CODA, Ryan

### DIFF
--- a/Calculator/BinaryCalculatorTest/BinaryCalculatorTest.swift
+++ b/Calculator/BinaryCalculatorTest/BinaryCalculatorTest.swift
@@ -8,18 +8,18 @@
 import XCTest
 @testable import Calculator
 class BinaryCalculatorTest: XCTestCase {
-
+    
     var binaryCalculator = BinaryCalculator()
     
     override func setUpWithError() throws {
-      binaryCalculator = BinaryCalculator()
-      try super.setUpWithError()
+        binaryCalculator = BinaryCalculator()
+        try super.setUpWithError()
     }
-
+    
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-
+    
     func testExample() throws {
         test_convertType_11_입력()
         test_convertType_음수_11_입력()
@@ -30,6 +30,7 @@ class BinaryCalculatorTest: XCTestCase {
         test_xorOperate_양의정수_두개()
         test_bitNotOperate_양의정수_한개()
         test_bitShiftOperate_양의정수_한개()
+        test_calculate()
     }
     
     func test_convertType_11_입력() {
@@ -66,6 +67,20 @@ class BinaryCalculatorTest: XCTestCase {
     
     func test_bitShiftOperate_양의정수_한개() {
         XCTAssertEqual(binaryCalculator.bitShiftOperate(for: -127, isRight: false), -254)
+    }
+    
+    func test_calculate() {
+        binaryCalculator = BinaryCalculator()
+        XCTAssertEqual(try binaryCalculator.calculate(operateSign: "+", operatedNumber: 0b10101, operatingNumber: 2), 23)
+        XCTAssertEqual(try binaryCalculator.calculate(operateSign: "-", operatedNumber: 1, operatingNumber: 1), 0)
+        XCTAssertEqual(try binaryCalculator.calculate(operateSign: "&", operatedNumber: 0b10101, operatingNumber: 2), 0)
+        XCTAssertEqual(try binaryCalculator.calculate(operateSign: "~&", operatedNumber: 0b10101, operatingNumber: 2), -1)
+        XCTAssertEqual(try binaryCalculator.calculate(operateSign: "|", operatedNumber: 0b10101, operatingNumber: 2), 23)
+        XCTAssertEqual(try binaryCalculator.calculate(operateSign: "~|", operatedNumber: 0b10101, operatingNumber: 2), -24)
+        XCTAssertEqual(try binaryCalculator.calculate(operateSign: "^|", operatedNumber: 0b10101, operatingNumber: 2), 23)
+        XCTAssertEqual(try binaryCalculator.calculate(operateSign: "~", operatedNumber: 0b10101, operatingNumber: 2), -22)
+        XCTAssertEqual(try binaryCalculator.calculate(operateSign: ">>", operatedNumber: 0b10101, operatingNumber: 2), 10)
+        XCTAssertEqual(try binaryCalculator.calculate(operateSign: "<<", operatedNumber: 0b10101, operatingNumber: 2), 42)
     }
 }
 

--- a/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		66A8953726135A6C00568300 /* BinaryCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66A8953626135A6C00568300 /* BinaryCalculator.swift */; };
 		66BCE71A2616E59E00DDB07B /* BinaryCalculatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66BCE7192616E59E00DDB07B /* BinaryCalculatorTest.swift */; };
 		66BCE746261753A100DDB07B /* MaximumDigitLimitable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66BCE745261753A100DDB07B /* MaximumDigitLimitable.swift */; };
+		66BCE7602617E71800DDB07B /* StackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66BCE75F2617E71800DDB07B /* StackTests.swift */; };
 		AAA492372615FCC4009DA3F5 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA492362615FCC4009DA3F5 /* Error.swift */; };
 		AADAD82D26135FFB00FC708F /* CalculationMethodSwitchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADAD82C26135FFB00FC708F /* CalculationMethodSwitchable.swift */; };
 		C713D9422570E5EB001C3AFC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D9412570E5EB001C3AFC /* AppDelegate.swift */; };
@@ -35,6 +36,13 @@
 			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
 			remoteInfo = Calculator;
 		};
+		66BCE7622617E71800DDB07B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C713D93D2570E5EB001C3AFC;
+			remoteInfo = Calculator;
+		};
 		D0807651261165C8005E3FAB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C713D9362570E5EB001C3AFC /* Project object */;
@@ -52,6 +60,9 @@
 		66BCE7192616E59E00DDB07B /* BinaryCalculatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryCalculatorTest.swift; sourceTree = "<group>"; };
 		66BCE71B2616E59E00DDB07B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		66BCE745261753A100DDB07B /* MaximumDigitLimitable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaximumDigitLimitable.swift; sourceTree = "<group>"; };
+		66BCE75D2617E71800DDB07B /* StackTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StackTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		66BCE75F2617E71800DDB07B /* StackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackTests.swift; sourceTree = "<group>"; };
+		66BCE7612617E71800DDB07B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AAA492362615FCC4009DA3F5 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		AADAD82C26135FFB00FC708F /* CalculationMethodSwitchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculationMethodSwitchable.swift; sourceTree = "<group>"; };
 		C713D93E2570E5EB001C3AFC /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -73,6 +84,13 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		66BCE7142616E59E00DDB07B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		66BCE75A2617E71800DDB07B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -135,12 +153,22 @@
 			path = BinaryCalculatorTest;
 			sourceTree = "<group>";
 		};
+		66BCE75E2617E71800DDB07B /* StackTests */ = {
+			isa = PBXGroup;
+			children = (
+				66BCE75F2617E71800DDB07B /* StackTests.swift */,
+				66BCE7612617E71800DDB07B /* Info.plist */,
+			);
+			path = StackTests;
+			sourceTree = "<group>";
+		};
 		C713D9352570E5EB001C3AFC = {
 			isa = PBXGroup;
 			children = (
 				C713D9402570E5EB001C3AFC /* Calculator */,
 				D080764D261165C8005E3FAB /* CalculatorTests */,
 				66BCE7182616E59E00DDB07B /* BinaryCalculatorTest */,
+				66BCE75E2617E71800DDB07B /* StackTests */,
 				C713D93F2570E5EB001C3AFC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -151,6 +179,7 @@
 				C713D93E2570E5EB001C3AFC /* Calculator.app */,
 				D080764C261165C8005E3FAB /* CalculatorTests.xctest */,
 				66BCE7172616E59E00DDB07B /* BinaryCalculatorTest.xctest */,
+				66BCE75D2617E71800DDB07B /* StackTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -219,6 +248,24 @@
 			productReference = 66BCE7172616E59E00DDB07B /* BinaryCalculatorTest.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		66BCE75C2617E71800DDB07B /* StackTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 66BCE7662617E71800DDB07B /* Build configuration list for PBXNativeTarget "StackTests" */;
+			buildPhases = (
+				66BCE7592617E71800DDB07B /* Sources */,
+				66BCE75A2617E71800DDB07B /* Frameworks */,
+				66BCE75B2617E71800DDB07B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				66BCE7632617E71800DDB07B /* PBXTargetDependency */,
+			);
+			name = StackTests;
+			productName = StackTests;
+			productReference = 66BCE75D2617E71800DDB07B /* StackTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C713D93D2570E5EB001C3AFC /* Calculator */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C713D9522570E5ED001C3AFC /* Build configuration list for PBXNativeTarget "Calculator" */;
@@ -267,6 +314,10 @@
 						CreatedOnToolsVersion = 12.4;
 						TestTargetID = C713D93D2570E5EB001C3AFC;
 					};
+					66BCE75C2617E71800DDB07B = {
+						CreatedOnToolsVersion = 12.4;
+						TestTargetID = C713D93D2570E5EB001C3AFC;
+					};
 					C713D93D2570E5EB001C3AFC = {
 						CreatedOnToolsVersion = 12.1;
 					};
@@ -292,12 +343,20 @@
 				C713D93D2570E5EB001C3AFC /* Calculator */,
 				D080764B261165C8005E3FAB /* CalculatorTests */,
 				66BCE7162616E59E00DDB07B /* BinaryCalculatorTest */,
+				66BCE75C2617E71800DDB07B /* StackTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		66BCE7152616E59E00DDB07B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		66BCE75B2617E71800DDB07B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -329,6 +388,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				66BCE71A2616E59E00DDB07B /* BinaryCalculatorTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		66BCE7592617E71800DDB07B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				66BCE7602617E71800DDB07B /* StackTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -367,6 +434,11 @@
 			isa = PBXTargetDependency;
 			target = C713D93D2570E5EB001C3AFC /* Calculator */;
 			targetProxy = 66BCE71C2616E59E00DDB07B /* PBXContainerItemProxy */;
+		};
+		66BCE7632617E71800DDB07B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C713D93D2570E5EB001C3AFC /* Calculator */;
+			targetProxy = 66BCE7622617E71800DDB07B /* PBXContainerItemProxy */;
 		};
 		D0807652261165C8005E3FAB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -428,6 +500,46 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.BinaryCalculatorTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Release;
+		};
+		66BCE7642617E71800DDB07B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = StackTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.StackTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Calculator.app/Calculator";
+			};
+			name = Debug;
+		};
+		66BCE7652617E71800DDB07B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = StackTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.StackTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -642,6 +754,15 @@
 			buildConfigurations = (
 				66BCE71E2616E59E00DDB07B /* Debug */,
 				66BCE71F2616E59E00DDB07B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		66BCE7662617E71800DDB07B /* Build configuration list for PBXNativeTarget "StackTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				66BCE7642617E71800DDB07B /* Debug */,
+				66BCE7652617E71800DDB07B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/Calculator.xcscheme
@@ -48,6 +48,16 @@
                ReferencedContainer = "container:Calculator.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "66BCE75C2617E71800DDB07B"
+               BuildableName = "StackTests.xctest"
+               BlueprintName = "StackTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/StackTests.xcscheme
+++ b/Calculator/Calculator.xcodeproj/xcshareddata/xcschemes/StackTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "66BCE75C2617E71800DDB07B"
+               BuildableName = "StackTests.xctest"
+               BlueprintName = "StackTests"
+               ReferencedContainer = "container:Calculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Calculator/Calculator/Error.swift
+++ b/Calculator/Calculator/Error.swift
@@ -35,6 +35,19 @@ enum DecimalCalculatorError: Error, CustomStringConvertible {
     }
 }
 
+enum StackError: Error, CustomStringConvertible {
+    case poppedItemIsNil
+    
+    var description: String {
+        switch self {
+        case .poppedItemIsNil:
+            return "숫자가 nil입니다."
+        default:
+            return "알 수 없는 에러입니다."
+        }
+    }
+}
+
 enum BinaryCalculatorError: Error, CustomStringConvertible {
     case divisionByZero
     case notAvailableOperator

--- a/Calculator/Calculator/Model/Calculators/BinaryCalculator.swift
+++ b/Calculator/Calculator/Model/Calculators/BinaryCalculator.swift
@@ -18,7 +18,7 @@ struct BinaryCalculator: Subtractable, Addable, TypeConvertible, MaximumDigitLim
         guard let userInputNumber = Int(number, radix: 2) else { throw  BinaryCalculatorError.notIntNumber }
         return userInputNumber % maximumDigit
     }
-
+    
     func convertType(inputOperator: String?) throws -> Operator {
         guard let userInputOperator = inputOperator else { throw BinaryCalculatorError.nilInputFoundWhileConvertingTypeOfOperator }
         switch userInputOperator {
@@ -78,7 +78,7 @@ struct BinaryCalculator: Subtractable, Addable, TypeConvertible, MaximumDigitLim
             return (operatedNumber << 1) % maximumDigit
         }
     }
-
+    
     mutating func calculate(operateSign: String?, operatedNumber: Int, operatingNumber: Int) throws -> Int {
         switch try convertType(inputOperator: operateSign) {
         case .addition:
@@ -99,27 +99,31 @@ struct BinaryCalculator: Subtractable, Addable, TypeConvertible, MaximumDigitLim
             return bitNotOperate(for: operatedNumber)
         case .rightBitShiftOperator:
             return bitShiftOperate(for: operatedNumber, isRight: true)
+        case .leftBitShiftOperator:
+            return bitShiftOperate(for: operatedNumber, isRight: false)
         default:
             throw BinaryCalculatorError.notAvailableOperator
         }
     }
-
-    mutating func executeOperate(of inputNumber: String?) {
-        do {
-            try stack.push(convertType(inputNumber: inputNumber))
-            for _ in 1...10 {
-                stack.push(try calculate(operateSign: readLine(), operatedNumber: stack.pop()!, operatingNumber: convertType(inputNumber: readLine())))
-            }
-        } catch {
-            print(error)
+    
+    func returnTopOfStack() throws -> Int {
+        if try stack.top() / maximumDigit >= 1 {
+            return try stack.top() % maximumDigit
+        } else {
+            return try stack.top()
         }
     }
     
-    func showTopOfStack() -> Int {
-        if stack.top! / 0b1000000000 >= 1 {
-            return stack.top! % 0b1000000000
-        } else {
-            return stack.top!
+    mutating func executeOperate(of inputNumber: String?) {
+        do {
+            try stack.push(convertType(inputNumber: inputNumber))
+            
+            for _ in 1...10 {
+                stack.push(try calculate(operateSign: readLine(), operatedNumber: stack.pop(), operatingNumber: convertType(inputNumber: readLine())))
+                print(try returnTopOfStack())
+            }
+        } catch {
+            print(error)
         }
     }
 }

--- a/Calculator/Calculator/Model/Calculators/DecimalCalculator.swift
+++ b/Calculator/Calculator/Model/Calculators/DecimalCalculator.swift
@@ -64,22 +64,24 @@ struct DecimalCalculator: Addable, Subtractable, TypeConvertible, MaximumDigitLi
         }
     }
     
-    mutating func executeOperate(of inputNumber: String?) {
-        do {
-           stack.push(try convertType(inputNumber: inputNumber))
-            for _ in 1...10 {
-                stack.push(try calculate(operateSign: readLine(), operatedNumber: stack.pop()!, operatingNumber: convertType(inputNumber: readLine())))
-            }
-        } catch {
-            print(error)
+    func returnTopOfStack() throws -> Double {
+        if try stack.top() / maximumDigit >= 1 {
+            return try stack.top().truncatingRemainder(dividingBy: maximumDigit) 
+        } else {
+            return try stack.top()
         }
     }
     
-    func showTopOfStack() -> Double {
-        if stack.top! / 1000000000.0 >= 1 {
-            return stack.top!.truncatingRemainder(dividingBy: 1000000000.0)
-        } else {
-            return stack.top!
+    mutating func executeOperate(of inputNumber: String?) {
+        do {
+            try stack.push(convertType(inputNumber: inputNumber))
+            
+            for _ in 1...10 {
+                stack.push(try calculate(operateSign: readLine(), operatedNumber: stack.pop(), operatingNumber: convertType(inputNumber: readLine())))
+                print(try returnTopOfStack())
+            }
+        } catch {
+            print(error)
         }
     }
 }

--- a/Calculator/Calculator/Model/Protocols/Subtractable.swift
+++ b/Calculator/Calculator/Model/Protocols/Subtractable.swift
@@ -15,6 +15,6 @@ protocol Subtractable {
 
 extension Subtractable {
     func subtract(_ operatedNumber: T, and operatingNumber: T) -> T {
-        return operatedNumber + operatingNumber
+        return operatedNumber - operatingNumber
     }
 }

--- a/Calculator/CalculatorTests/CalculatorTests.swift
+++ b/Calculator/CalculatorTests/CalculatorTests.swift
@@ -14,7 +14,7 @@ class CalculatorTests: XCTestCase {
     var testDecimalCalculator = DecimalCalculator()
     
     override func setUpWithError() throws {
-       
+        
         try super.setUpWithError()
     }
     

--- a/Calculator/Operator.swift
+++ b/Calculator/Operator.swift
@@ -20,5 +20,4 @@ enum Operator {
     case bitNotOperator
     case rightBitShiftOperator
     case leftBitShiftOperator
-    
 }

--- a/Calculator/Stack.swift
+++ b/Calculator/Stack.swift
@@ -9,19 +9,24 @@ import Foundation
 
 struct Stack<T> {
     var list: [T]
-    var top: T? {
-        return self.list.last
-    }
+    
     var isEmpty: Bool {
         return self.list.isEmpty
+    }
+    
+    func top() throws -> T {
+        guard let topout = self.list.last else { throw
+            StackError.poppedItemIsNil }
+        return topout
     }
     
     mutating func push(_ item: T) {
         self.list.append(item)
     }
     
-    mutating func pop() -> T? {
-        return self.list.popLast()
+    mutating func pop() throws -> T {
+        guard let popout = self.list.popLast() else { throw StackError.poppedItemIsNil }
+        return popout
     }
     
     mutating func reset() {
@@ -32,3 +37,4 @@ struct Stack<T> {
         self.list = list
     }
 }
+

--- a/Calculator/StackTests/Info.plist
+++ b/Calculator/StackTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Calculator/StackTests/StackTests.swift
+++ b/Calculator/StackTests/StackTests.swift
@@ -1,0 +1,51 @@
+//
+//  StackTests.swift
+//  StackTests
+//
+//  Created by ysp on 2021/04/03.
+//
+
+import XCTest
+@testable import Calculator
+class StackTests: XCTestCase {
+    
+    var stackDecimalTest = Stack<Double>()
+    var stackBinaryTest = Stack<Int>()
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+    }
+    
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testExample() throws {
+        test_stack_pop()
+        test_stack_pop_error()
+        test_stack_top()
+        test_stack_isEmpty()
+    }
+    
+    func test_stack_pop() {
+        stackDecimalTest = Stack<Double>(list:[1, 2])
+        XCTAssertEqual(try stackDecimalTest.pop(), 2)
+    }
+    
+    func test_stack_pop_error() {
+        stackDecimalTest = Stack<Double>()
+        XCTAssertThrowsError(try stackDecimalTest.pop()) { (error) in
+            XCTAssertEqual(error as! StackError, StackError.poppedItemIsNil)
+        }
+    }
+    
+    func test_stack_top() {
+        stackDecimalTest = Stack<Double>(list:[1, 2])
+        XCTAssertEqual(try stackDecimalTest.top(), 2)
+    }
+    
+    func test_stack_isEmpty() {
+        stackDecimalTest = Stack<Double>()
+        XCTAssertEqual(stackDecimalTest.isEmpty, true)
+    }
+}


### PR DESCRIPTION
@seizze

안녕하세요 

## 코드를 작성할 때 고민됐던 점
- 어떤 단위로 프로토콜를 정할 것 인가
- 유닛테스트에서 throw하는 에러를 확인하는 방법
- 유닛테스트의 단위
- 최대표시숫자 9자리수로 제한하기
- 에러처리 방법

## 조언을 얻고 싶은 부분
- 예외처리할 때 에러를 throw하는 방법으로만 처리하고 있는데 더 좋은 방법이 있을까요?
- 현업에서는 페어프로그래밍을 어떻게하는지 (우리는 줌으로 했는데) 궁금합니다.
- 전체 테스트를 수행할 때 testExample 메소드를 통해 개별 test 메소드들을 호출하는 과정에서
   각 개별테스트 시작시 초기화를 위해 인스턴스를 매번 만들어줬는데 이 작업이 너무 반복되는 느낌입니다.
   인스턴스를 한번만 만들어서 이용하고 싶은데  testExample에서 개별테스트들이 서로 간섭받지 않으려면 어떻게 해야할까요?
```swift
import XCTest
@testable import Calculator
class StackTests: XCTestCase {
    
    var stackDecimalTest = Stack<Double>()
    var stackBinaryTest = Stack<Int>()
    
    override func setUpWithError() throws {
        try super.setUpWithError()
    }
    
    override func tearDownWithError() throws {
        // Put teardown code here. This method is called after the invocation of each test method in the class.
    }
    
    func testExample() throws {
        test_stack_pop()
        test_stack_pop_error()
        test_stack_top()
        test_stack_isEmpty()
    }
    
    func test_stack_pop() {
        stackDecimalTest = Stack<Double>(list:[1, 2])
        XCTAssertEqual(try stackDecimalTest.pop(), 2)
    }
    
    func test_stack_pop_error() {
        stackDecimalTest = Stack<Double>()
        XCTAssertThrowsError(try stackDecimalTest.pop()) { (error) in
            XCTAssertEqual(error as! StackError, StackError.poppedItemIsNil)
        }
    }
    
    func test_stack_top() {
        stackDecimalTest = Stack<Double>(list:[1, 2])
        XCTAssertEqual(try stackDecimalTest.top(), 2)
    }
    
    func test_stack_isEmpty() {
        stackDecimalTest = Stack<Double>()
        XCTAssertEqual(stackDecimalTest.isEmpty, true)
    }
}
```

## 해결하지 못한 부분
- 아래 코드를 보시면 calculate 메서드는 `operateSign`, `operatedNumber`, `operatingNumber`  매개변수에 넣어줘야 할 전달인자가 필요합니다.
  하지만 bitShift연산은 operatingNumber를 필요로 하지 않는데 메서드 실행을 위해 불필요하게 입력받아야 합니다.
  bitShift연산만 따로 구현에서 처리하는 방법도 있을 것 같은데 이렇게 처리하는 것은 처리 방식이 일관적이지 않아 석연치 않습니다.
  좋은 방법이 있을까요?
```swift
 mutating func calculate(operateSign: String?, operatedNumber: Int, operatingNumber: Int) throws -> Int {
        switch try convertType(inputOperator: operateSign) {
       /* case .addition:
            return add(operatedNumber, and: operatingNumber)
        case .subtraction:
            return subtract(operatedNumber, and: operatingNumber)
        case .andOperator:
            return andOperate(with: operatedNumber, and: operatingNumber)
        case .nandOperator:
            return nandOperate(with: operatedNumber, and: operatingNumber)
        case .orOperator:
            return orOperate(with: operatedNumber, and: operatingNumber)
        case .norOperator:
            return norOperate(with: operatedNumber, and: operatingNumber)
        case .xorOperator:
            return xorOperate(with: operatedNumber, and: operatingNumber)*/
        case .bitNotOperator:
            return bitNotOperate(for: operatedNumber)
       /* case .rightBitShiftOperator:
            return bitShiftOperate(for: operatedNumber, isRight: true)
        case .leftBitShiftOperator:
            return bitShiftOperate(for: operatedNumber, isRight: false)
        default:
            throw BinaryCalculatorError.notAvailableOperator */
        }
    }
    ```
